### PR TITLE
fix: for-loop escape

### DIFF
--- a/misc/python_ijele/src/ijele.py
+++ b/misc/python_ijele/src/ijele.py
@@ -8,8 +8,7 @@ def main():
             if keyword in text:
                 print('Play by the rules!!! Try again.')
                 return
-            else:
-                exec(text)
+        exec(text)
     else:
         print('Wrong code to break out. Sorry, try again!')
 


### PR DESCRIPTION
In `python_ijele`, a logic error in for-loop causes the player to `exec` using any keyword after `eval` in the list.